### PR TITLE
sync vhost with cloud-hypervisor/vhost_rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,18 @@ license = "Apache-2.0 or BSD-3-Clause"
 [features]
 default = []
 vhost-vsock = []
-vhost-kern = ["vm-memory/backend-mmap"]
+vhost-kern = ["vm-memory"]
 vhost-user-master = []
 vhost-user-slave = []
 
 [dependencies]
-bitflags = ">=1.0.1"
-libc = ">=0.2.39"
-
+bitflags = "1.1.0"
+libc = "0.2.67"
 vmm-sys-util = ">=0.3.1"
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory.git", branch = "master", optional = true }
+
+[dependencies.vm-memory]
+git = "https://github.com/rust-vmm/vm-memory"
+optional = true
 
 [dev-dependencies]
-tempfile = "3.0.5"
+tempfile = "3.1.0"

--- a/src/vhost_user/connection.rs
+++ b/src/vhost_user/connection.rs
@@ -525,6 +525,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn send_data() {
         let listener = Listener::new(UNIX_SOCKET_DATA, true).unwrap();
         listener.set_nonblocking(true).unwrap();
@@ -550,6 +551,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn send_fd() {
         let listener = Listener::new(UNIX_SOCKET_FD, true).unwrap();
         listener.set_nonblocking(true).unwrap();
@@ -703,6 +705,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn send_recv() {
         let listener = Listener::new(UNIX_SOCKET_SEND, true).unwrap();
         listener.set_nonblocking(true).unwrap();

--- a/src/vhost_user/connection.rs
+++ b/src/vhost_user/connection.rs
@@ -489,7 +489,6 @@ mod tests {
 
     use self::tempfile::tempfile;
     use super::*;
-    use libc;
     use std::fs::File;
     use std::io::{Read, Seek, SeekFrom, Write};
     use std::os::unix::io::FromRawFd;
@@ -513,15 +512,6 @@ mod tests {
         // accept on a fd without incoming connection
         let conn = listener.accept().unwrap();
         assert!(conn.is_none());
-
-        listener.set_nonblocking(true).unwrap();
-
-        // accept on a closed fd
-        unsafe {
-            libc::close(listener.as_raw_fd());
-        }
-        let conn2 = listener.accept();
-        assert!(conn2.is_err());
     }
 
     #[test]

--- a/src/vhost_user/dummy_slave.rs
+++ b/src/vhost_user/dummy_slave.rs
@@ -218,28 +218,30 @@ impl VhostUserSlaveReqHandler for DummySlaveReqHandler {
 
     fn get_config(
         &mut self,
-        buf: &[u8],
         offset: u32,
+        size: u32,
         _flags: VhostUserConfigFlags,
     ) -> Result<Vec<u8>> {
         if self.acked_features & VhostUserProtocolFeatures::CONFIG.bits() == 0 {
             return Err(Error::InvalidOperation);
-        } else if offset >= VHOST_USER_MAX_CONFIG_SIZE
-            || buf.len() > VHOST_USER_MAX_CONFIG_SIZE as usize
-            || offset + buf.len() as u32 > VHOST_USER_MAX_CONFIG_SIZE
+        } else if offset < VHOST_USER_CONFIG_OFFSET
+            || offset >= VHOST_USER_CONFIG_SIZE
+            || size > VHOST_USER_CONFIG_SIZE - VHOST_USER_CONFIG_OFFSET
+            || size + offset > VHOST_USER_CONFIG_SIZE
         {
             return Err(Error::InvalidParam);
         }
-        Ok(vec![0xa5; buf.len()])
+        Ok(vec![0xa5; size as usize])
     }
 
-    fn set_config(&mut self, buf: &[u8], offset: u32, _flags: VhostUserConfigFlags) -> Result<()> {
+    fn set_config(&mut self, offset: u32, buf: &[u8], _flags: VhostUserConfigFlags) -> Result<()> {
         let size = buf.len() as u32;
         if self.acked_features & VhostUserProtocolFeatures::CONFIG.bits() == 0 {
             return Err(Error::InvalidOperation);
-        } else if offset >= VHOST_USER_MAX_CONFIG_SIZE
-            || size > VHOST_USER_MAX_CONFIG_SIZE
-            || offset + size > VHOST_USER_MAX_CONFIG_SIZE
+        } else if offset < VHOST_USER_CONFIG_OFFSET
+            || offset >= VHOST_USER_CONFIG_SIZE
+            || size > VHOST_USER_CONFIG_SIZE - VHOST_USER_CONFIG_OFFSET
+            || size + offset > VHOST_USER_CONFIG_SIZE
         {
             return Err(Error::InvalidParam);
         }

--- a/src/vhost_user/master.rs
+++ b/src/vhost_user/master.rs
@@ -167,9 +167,12 @@ impl VhostBackend for Master {
         node.wait_for_ack(&hdr).map_err(|e| e.into())
     }
 
+    // Clippy doesn't seem to know that if let with && is still experimental
+    #[allow(clippy::unnecessary_unwrap)]
     fn set_log_base(&mut self, base: u64, fd: Option<RawFd>) -> Result<()> {
         let mut node = self.node.lock().unwrap();
         let val = VhostUserU64::new(base);
+
         if node.acked_protocol_features & VhostUserProtocolFeatures::LOG_SHMFD.bits() != 0
             && fd.is_some()
         {

--- a/src/vhost_user/master.rs
+++ b/src/vhost_user/master.rs
@@ -356,12 +356,11 @@ impl VhostUserMaster for Master {
             return error_code(VhostUserError::InvalidOperation);
         }
 
-        // vhost-user spec states that:
+        // TODO: vhost-user spec states that:
         // "Master payload: virtio device config space"
         // But what content should the payload contains for a get_config() request?
-        // We use all zero filled buffer here.
-        let buf = vec![0u8; body.size as usize];
-        let hdr = node.send_request_with_payload(MasterReq::GET_CONFIG, &body, &buf, None)?;
+        // So current implementation doesn't conform to the spec.
+        let hdr = node.send_request_with_body(MasterReq::GET_CONFIG, &body, None)?;
         let (reply, buf, rfds) = node.recv_reply_with_payload::<VhostUserConfig>(&hdr)?;
         if rfds.is_some() {
             Endpoint::<MasterReq>::close_rfds(rfds);
@@ -556,7 +555,7 @@ impl MasterInternal {
         if !reply.is_reply_for(hdr)
             || reply.get_size() as usize != mem::size_of::<T>() + bytes
             || rfds.is_some()
-            || !body.is_valid()
+            || body.is_valid()
         {
             Endpoint::<MasterReq>::close_rfds(rfds);
             return Err(VhostUserError::InvalidMessage);

--- a/src/vhost_user/master.rs
+++ b/src/vhost_user/master.rs
@@ -631,6 +631,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn create_master() {
         let listener = Listener::new(UNIX_SOCKET_MASTER, true).unwrap();
         listener.set_nonblocking(true).unwrap();
@@ -656,6 +657,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_create_failure() {
         let _ = Listener::new(UNIX_SOCKET_MASTER2, true).unwrap();
         let _ = Listener::new(UNIX_SOCKET_MASTER2, false).is_err();
@@ -670,6 +672,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_features() {
         let (mut master, mut peer) = create_pair(UNIX_SOCKET_MASTER3);
 
@@ -701,6 +704,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_protocol_features() {
         let (mut master, mut peer) = create_pair(UNIX_SOCKET_MASTER4);
 

--- a/src/vhost_user/master.rs
+++ b/src/vhost_user/master.rs
@@ -604,7 +604,7 @@ impl MasterInternal {
     #[inline]
     fn new_request_header(request: MasterReq, size: u32) -> VhostUserMsgHeader<MasterReq> {
         // TODO: handle NEED_REPLY flag
-        VhostUserMsgHeader::new(request, 0, size)
+        VhostUserMsgHeader::new(request, 0x1, size)
     }
 }
 

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -638,7 +638,7 @@ bitflags! {
 }
 
 /// Max entries in one virtio-fs slave request.
-const VHOST_USER_FS_SLAVE_ENTRIES: usize = 8;
+pub const VHOST_USER_FS_SLAVE_ENTRIES: usize = 8;
 
 /// Slave request message to update the MMIO window.
 #[repr(packed)]

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -343,6 +343,8 @@ bitflags! {
         const SLAVE_SEND_FD = 0x0000_0400;
         /// Allow the slave to register a host notifier.
         const HOST_NOTIFIER = 0x0000_0800;
+        /// Support inflight shmfd.
+        const INFLIGHT_SHMFD = 0x0000_1000;
     }
 }
 

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -789,6 +789,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn check_user_config_msg() {
         let mut msg = VhostUserConfig::new(
             VHOST_USER_CONFIG_OFFSET,

--- a/src/vhost_user/mod.rs
+++ b/src/vhost_user/mod.rs
@@ -28,9 +28,9 @@ pub use self::connection::Listener;
 mod master;
 #[cfg(feature = "vhost-user-master")]
 pub use self::master::{Master, VhostUserMaster};
-#[cfg(feature = "vhost-user-master")]
+#[cfg(any(feature = "vhost-user-master", feature = "vhost-user-slave"))]
 mod master_req_handler;
-#[cfg(feature = "vhost-user-master")]
+#[cfg(any(feature = "vhost-user-master", feature = "vhost-user-slave"))]
 pub use self::master_req_handler::{MasterReqHandler, VhostUserMasterReqHandler};
 
 #[cfg(feature = "vhost-user-slave")]

--- a/src/vhost_user/mod.rs
+++ b/src/vhost_user/mod.rs
@@ -43,6 +43,7 @@ mod slave_req_handler;
 pub use self::slave_req_handler::{SlaveReqHandler, VhostUserSlaveReqHandler};
 #[cfg(feature = "vhost-user-slave")]
 mod slave_fs_cache;
+#[cfg(feature = "vhost-user-slave")]
 pub use self::slave_fs_cache::SlaveFsCacheReq;
 
 pub mod sock_ctrl_msg;

--- a/src/vhost_user/slave_fs_cache.rs
+++ b/src/vhost_user/slave_fs_cache.rs
@@ -1,0 +1,94 @@
+// Copyright (C) 2020 Alibaba Cloud Computing. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::connection::Endpoint;
+use super::message::*;
+use super::{Error, HandlerResult, Result, VhostUserMasterReqHandler};
+use std::io;
+use std::mem;
+use std::os::unix::io::RawFd;
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex};
+
+struct SlaveFsCacheReqInternal {
+    sock: Endpoint<SlaveReq>,
+}
+
+/// A vhost-user slave endpoint which sends fs cache requests to the master
+#[derive(Clone)]
+pub struct SlaveFsCacheReq {
+    // underlying Unix domain socket for communication
+    node: Arc<Mutex<SlaveFsCacheReqInternal>>,
+
+    // whether the endpoint has encountered any failure
+    error: Option<i32>,
+}
+
+impl SlaveFsCacheReq {
+    fn new(ep: Endpoint<SlaveReq>) -> Self {
+        SlaveFsCacheReq {
+            node: Arc::new(Mutex::new(SlaveFsCacheReqInternal { sock: ep })),
+            error: None,
+        }
+    }
+
+    /// Create a new instance.
+    pub fn from_stream(sock: UnixStream) -> Self {
+        Self::new(Endpoint::<SlaveReq>::from_stream(sock))
+    }
+
+    fn send_message(
+        &mut self,
+        flags: SlaveReq,
+        fs: &VhostUserFSSlaveMsg,
+        fds: Option<&[RawFd]>,
+    ) -> Result<()> {
+        self.check_state()?;
+
+        let len = mem::size_of::<VhostUserFSSlaveMsg>();
+        let mut hdr = VhostUserMsgHeader::new(flags, 0, len as u32);
+        hdr.set_need_reply(true);
+        self.node.lock().unwrap().sock.send_message(&hdr, fs, fds)?;
+
+        self.wait_for_ack(&hdr)
+    }
+
+    fn wait_for_ack(&mut self, hdr: &VhostUserMsgHeader<SlaveReq>) -> Result<()> {
+        self.check_state()?;
+        let (reply, body, rfds) = self.node.lock().unwrap().sock.recv_body::<VhostUserU64>()?;
+        if !reply.is_reply_for(&hdr) || rfds.is_some() || !body.is_valid() {
+            Endpoint::<SlaveReq>::close_rfds(rfds);
+            return Err(Error::InvalidMessage);
+        }
+        if body.value != 0 {
+            return Err(Error::MasterInternalError);
+        }
+        Ok(())
+    }
+
+    fn check_state(&self) -> Result<()> {
+        match self.error {
+            Some(e) => Err(Error::SocketBroken(std::io::Error::from_raw_os_error(e))),
+            None => Ok(()),
+        }
+    }
+
+    /// Mark endpoint as failed with specified error code.
+    pub fn set_failed(&mut self, error: i32) {
+        self.error = Some(error);
+    }
+}
+
+impl VhostUserMasterReqHandler for SlaveFsCacheReq {
+    /// Handle virtio-fs map file requests from the slave.
+    fn fs_slave_map(&mut self, fs: &VhostUserFSSlaveMsg, fd: RawFd) -> HandlerResult<()> {
+        self.send_message(SlaveReq::FS_MAP, fs, Some(&[fd]))
+            .or_else(|e| Err(io::Error::new(io::ErrorKind::Other, format!("{}", e))))
+    }
+
+    /// Handle virtio-fs unmap file requests from the slave.
+    fn fs_slave_unmap(&mut self, fs: &VhostUserFSSlaveMsg) -> HandlerResult<()> {
+        self.send_message(SlaveReq::FS_UNMAP, fs, None)
+            .or_else(|e| Err(io::Error::new(io::ErrorKind::Other, format!("{}", e))))
+    }
+}

--- a/src/vhost_user/slave_req_handler.rs
+++ b/src/vhost_user/slave_req_handler.rs
@@ -278,9 +278,7 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
                 self.set_config(&hdr, size, &buf)?;
             }
             MasterReq::SET_SLAVE_REQ_FD => {
-                if self.acked_protocol_features & VhostUserProtocolFeatures::SLAVE_SEND_FD.bits()
-                    == 0
-                {
+                if self.acked_protocol_features & VhostUserProtocolFeatures::SLAVE_REQ.bits() == 0 {
                     return Err(Error::InvalidOperation);
                 }
                 self.set_slave_req_fd(&hdr, rfds)?;

--- a/src/vhost_user/sock_ctrl_msg.rs
+++ b/src/vhost_user/sock_ctrl_msg.rs
@@ -182,8 +182,9 @@ fn raw_recvmsg(fd: RawFd, iovecs: &mut [iovec], in_fds: &mut [RawFd]) -> Result<
         return Err(Error::last());
     }
 
+    // When the connection is closed recvmsg() doesn't give an explicit error
     if total_read == 0 && msg.msg_controllen < size_of::<cmsghdr>() {
-        return Ok((0, 0));
+        return Err(Error::new(libc::ECONNRESET));
     }
 
     let mut cmsg_ptr = msg.msg_control as *mut cmsghdr;

--- a/src/vhost_user/sock_ctrl_msg.rs
+++ b/src/vhost_user/sock_ctrl_msg.rs
@@ -176,7 +176,7 @@ fn raw_recvmsg(fd: RawFd, iovecs: &mut [iovec], in_fds: &mut [RawFd]) -> Result<
 
     // Safe because the msghdr was properly constructed from valid (or null) pointers of the
     // indicated length and we check the return value.
-    let total_read = unsafe { recvmsg(fd, &mut msg, 0) };
+    let total_read = unsafe { recvmsg(fd, &mut msg, libc::MSG_WAITALL) };
 
     if total_read == -1 {
         return Err(Error::last());


### PR DESCRIPTION
This pull request syncs all modifications to cloud-hypervisor/vhost_rs to this vhost repo, with some improvements from Alibaba on top of it.

The purpose of this sync is to build a common code base that could be used by both cloud-hypervisor and Alibaba's dragonball, and maybe by other projects as well. So people could collaborate on the common library, and all could benefit from it.

This pull request is targeted at dragonball branch, I hope it could be merged into master branch when everything settles down, and cloud-hypervisor itself could switch to this crate soon, instead of maintaining a private cloud-hypervisor/vhost_rs code base.

I went through all commits that touched cloud-hypervisor/vhost_rs directory and ported them to vhost repo dragonball branch. The general rules are

- Perfer code from cloud-hypervisor/vhost_rs. So you may see some reverts, because cloud-hypervisor/vhost_rs has similar commits and the original commits are reverted.
- Preserve the original authors and dates, but change "vhost_rs" prefix to "vhost-user"
- Some commits touched code outside cloud-hypervisor/vhost_rs, which got deleted in this port
- All Cargo.toml updates are merged into one commit (the first patch)
- Commits from Alibaba are on top of the tree (the last two commits)

Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>