### PR TITLE
Fix VhostUserConfig message validation

### DIFF
--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -584,11 +584,9 @@ impl VhostUserMsgValidator for VhostUserConfig {
     fn is_valid(&self) -> bool {
         if (self.flags & !VhostUserConfigFlags::all().bits()) != 0 {
             return false;
-        } else if self.offset < VHOST_USER_CONFIG_OFFSET
-            || self.offset >= VHOST_USER_CONFIG_SIZE
-            || self.size == 0
-            || self.size > (VHOST_USER_CONFIG_SIZE - VHOST_USER_CONFIG_OFFSET)
-            || self.size + self.offset > VHOST_USER_CONFIG_SIZE
+        } else if self.size == 0
+            || self.size > VHOST_USER_CONFIG_SIZE
+            || self.size + self.offset >= VHOST_USER_CONFIG_SIZE
         {
             return false;
         }


### PR DESCRIPTION
The offset field in the VhostUserConfig message is used to indicate
that the data included in the payload comes from that offset within
the virtio configuration space. This used in SET_CONFIG messages to
send partial updates. For example to update the WCE field in
VirtioBlockConfig, only a single byte payload is needed.

It has no relationship with the actual disposition of the
configuration space in the device memory, so don't check that in the
validation.

Signed-off-by: Sergio Lopez <slp@redhat.com>