### PR TITLE
vhost-user: Require SlaveListener users to provide a Listener

### DIFF
--- a/src/vhost_user/mod.rs
+++ b/src/vhost_user/mod.rs
@@ -186,7 +186,8 @@ mod tests {
         path: &str,
         backend: Arc<Mutex<S>>,
     ) -> (Master, SlaveReqHandler<S>) {
-        let mut slave_listener = SlaveListener::new(path, true, backend).unwrap();
+        let listener = Listener::new(path, true).unwrap();
+        let mut slave_listener = SlaveListener::new(listener, backend).unwrap();
         let master = Master::connect(path, 1).unwrap();
         (master, slave_listener.accept().unwrap().unwrap())
     }

--- a/src/vhost_user/slave.rs
+++ b/src/vhost_user/slave.rs
@@ -19,11 +19,9 @@ pub struct SlaveListener<S: VhostUserSlaveReqHandler> {
 /// of a Slave on success.
 impl<S: VhostUserSlaveReqHandler> SlaveListener<S> {
     /// Create a unix domain socket for incoming master connections.
-    ///
-    /// Be careful, the file at `path` will be unlinked if unlink is true
-    pub fn new(path: &str, unlink: bool, backend: Arc<Mutex<S>>) -> Result<Self> {
+    pub fn new(listener: Listener, backend: Arc<Mutex<S>>) -> Result<Self> {
         Ok(SlaveListener {
-            listener: Listener::new(path, unlink)?,
+            listener,
             backend: Some(backend),
         })
     }


### PR DESCRIPTION
Require SlaveListener users to provide a pre-instanced Listener. This
is allow callers to create the Listener in a different context, a
feature which enables to implement different sandboxing strategies.

Signed-off-by: Sergio Lopez <slp@redhat.com>