### PR TITLE
Fix backend compatibility with QEMU as frontend

### DIFF
--- a/src/vhost_user/slave_req_handler.rs
+++ b/src/vhost_user/slave_req_handler.rs
@@ -155,7 +155,6 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
                 let msg = self.extract_request_body::<VhostUserU64>(&hdr, size, &buf)?;
                 self.backend.lock().unwrap().set_features(msg.value)?;
                 self.acked_virtio_features = msg.value;
-                self.update_reply_ack_flag();
             }
             MasterReq::SET_MEM_TABLE => {
                 let res = self.set_mem_table(&hdr, size, &buf, rfds);
@@ -537,7 +536,6 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         let vflag = VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
         let pflag = VhostUserProtocolFeatures::REPLY_ACK;
         if (self.virtio_features & vflag) != 0
-            && (self.acked_virtio_features & vflag) != 0
             && self.protocol_features.contains(pflag)
             && (self.acked_protocol_features & pflag.bits()) != 0
         {

--- a/src/vhost_user/slave_req_handler.rs
+++ b/src/vhost_user/slave_req_handler.rs
@@ -568,7 +568,7 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         req: &VhostUserMsgHeader<MasterReq>,
         res: Result<()>,
     ) -> Result<()> {
-        if self.reply_ack_enabled {
+        if self.reply_ack_enabled && req.is_need_reply() {
             let hdr = self.new_reply_header::<VhostUserU64>(req, 0)?;
             let val = match res {
                 Ok(_) => 0,


### PR DESCRIPTION
Wasn’t sure whether to PR this here or to @arronwy’s dragonball branch, which I see is a [PR](https://github.com/rust-vmm/vhost/pull/10) to rust-vmm’s copy of the repo.

I’ve been trying to use cloud-hypervisor’s vhost-user-net backend with QEMU. In doing so, I’ve found a few compatibility problems resulting from cloud-hypervisor not quite correctly following the vhost-user spec. This series contains the changes to this crate required to use the cloud-hypervisor vhost-user-net with QEMU. There’s another thing that’ll have to be fixed in the cloud-hypervisor tree itself.